### PR TITLE
Removing folders outside the graph

### DIFF
--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
@@ -4,12 +4,14 @@ import com.github.leandroborgesferreira.dagcommand.domain.AdjacencyList
 import com.github.leandroborgesferreira.dagcommand.domain.ModuleBuildStage
 import java.util.*
 
-fun affectedModules(adjacencyList: AdjacencyList, modules: List<String>): Set<String> {
+fun affectedModules(adjacencyList: AdjacencyList, changedFolders: List<String>): Set<String> {
     val resultSet: MutableSet<String> = mutableSetOf()
 
-    modules.forEach { module ->
-        traverseGraph(adjacencyList, module, resultSet)
-    }
+    changedFolders
+        .filter { folder -> adjacencyList.keys.contains(folder) }
+        .forEach { module ->
+            traverseGraph(adjacencyList, module, resultSet)
+        }
 
     return resultSet
 }

--- a/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
+++ b/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
@@ -9,6 +9,13 @@ import kotlin.test.assertEquals
 class GraphKtTest {
 
     @Test
+    fun `proves that affected modules do not include folders that are not modules`() {
+        val resultSet = affectedModules(simpleGraph(), listOf("B", "C", "not", "in", "the", "graph"))
+
+        assertEquals(setOf("B", "C", "E", "F"), resultSet)
+    }
+
+    @Test
     fun `proves that affected graph works for middle position change`() {
         val resultSet = affectedModules(simpleGraph(), listOf("B", "C"))
 

--- a/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
+++ b/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
@@ -32,5 +32,6 @@ fun disconnectedGraph(): Map<String, Set<String>> =
         "B" to emptySet(),
         "C" to emptySet(),
         "D" to emptySet(),
+        "E" to emptySet(),
         "F" to emptySet()
     )


### PR DESCRIPTION
In this PR there's a fix for folders outside of the gradle modules getting included in the affected modules