### PR TITLE
Fixing changed modules parse

### DIFF
--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModules.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModules.kt
@@ -1,10 +1,12 @@
 package com.github.leandroborgesferreira.dagcommand.logic
 
+import com.github.leandroborgesferreira.dagcommand.domain.AdjacencyList
 import com.github.leandroborgesferreira.dagcommand.utils.CommandExecutor
 
-fun changedModules(commandExec: CommandExecutor, defaultBranch: String): List<String> =
+fun changedModules(commandExec: CommandExecutor, defaultBranch: String, adjacencyList: AdjacencyList): List<String> =
     commandExec.runCommand("git diff $defaultBranch --dirstat=files")
         .map(::parseModuleName)
+        .filter(adjacencyList.keys::contains)
         .distinct()
 
 private fun parseModuleName(commandResult: String): String =

--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
@@ -6,7 +6,6 @@ fun affectedModules(adjacencyList: AdjacencyList, changedFolders: List<String>):
     val resultSet: MutableSet<String> = mutableSetOf()
 
     changedFolders
-        .filter { folder -> adjacencyList.keys.contains(folder) }
         .forEach { module ->
             traverseGraph(adjacencyList, module, resultSet)
         }

--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/Graph.kt
@@ -2,10 +2,10 @@ package com.github.leandroborgesferreira.dagcommand.logic
 
 import com.github.leandroborgesferreira.dagcommand.domain.AdjacencyList
 
-fun affectedModules(adjacencyList: AdjacencyList, changedFolders: List<String>): Set<String> {
+fun affectedModules(adjacencyList: AdjacencyList, changedModules: List<String>): Set<String> {
     val resultSet: MutableSet<String> = mutableSetOf()
 
-    changedFolders
+    changedModules
         .forEach { module ->
             traverseGraph(adjacencyList, module, resultSet)
         }

--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/task/CommandTask.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/task/CommandTask.kt
@@ -75,9 +75,10 @@ open class CommandTask : DefaultTask() {
             }
         }
 
-        val changedModules: List<String> = changedModules(CommandExec, config.defaultBranch).also { modules ->
-            println("Changed modules: ${modules.joinToString()}\n")
-        }
+        val changedModules: List<String> =
+            changedModules(CommandExec, config.defaultBranch, adjacencyList).also { modules ->
+                println("Changed modules: ${modules.joinToString()}\n")
+            }
 
         val affectedModules: Set<String> = affectedModules(adjacencyList, changedModules).also { modules ->
             println("Affected modules: ${modules.joinToString()}\n")

--- a/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModulesKtTest.kt
+++ b/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModulesKtTest.kt
@@ -2,6 +2,7 @@ package com.github.leandroborgesferreira.dagcommand.logic
 
 import com.github.leandroborgesferreira.dagcommand.utils.CommandExec
 import com.github.leandroborgesferreira.dagcommand.utils.CommandExecutor
+import com.github.leandroborgesferreira.dagcommand.utils.simpleGraph
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -11,22 +12,24 @@ import kotlin.test.assertEquals
 class ChangedModulesKtTest {
 
     private val changedModules = listOf(
-        "4.4% module1/src/androidTest/java/com/module1/",
-        "7.3% module1/src/main/java/com/module1/android/",
-        "4.9% module1/src/main/java/com/module1/features/feature1/",
-        "3.4% module1/src/main/java/com/module1/features/search/",
-        "4.9% module1/src/main/java/com/module1/features/information/",
-        "5.8% module1/src/main/java/com/module1/network/",
-        "10.7% module1/src/main/java/com/module1/",
-        "3.4% module1/src/test/java/com/module1/android/",
-        "3.9% module1/",
-        "5.8% inbox/src/main/java/com/module1/inbox/messages/",
-        "3.9% inbox/src/",
-        "4.4% network/src/main/java/com/module1/network/responsemodels/",
-        "4.9% repositories/src/main/java/com/module1/repositories/",
-        "3.9% resources/src/main/res/drawable/",
-        "8.8% resources/src/main/res/",
-        "3.9% favorites/src/main/java/com/module1/favorites/"
+        "4.4% A/src/androidTest/java/com/module1/",
+        "7.3% A/src/main/java/com/module1/android/",
+        "4.9% A/src/main/java/com/module1/features/feature1/",
+        "3.4% A/src/main/java/com/module1/features/search/",
+        "4.9% A/src/main/java/com/module1/features/information/",
+        "5.8% A/src/main/java/com/module1/network/",
+        "10.7% A/src/main/java/com/module1/",
+        "3.4% A/src/test/java/com/module1/android/",
+        "3.9% A/",
+        "5.8% B/src/main/java/com/module1/inbox/messages/",
+        "3.9% B/src/",
+        "4.4% C/src/main/java/com/module1/network/responsemodels/",
+        "4.9% D/src/main/java/com/module1/repositories/",
+        "3.9% E/src/main/res/drawable/",
+        "8.8% E/src/main/res/",
+        "3.9% F/src/main/java/com/module1/favorites/",
+        "1.9% Z/src/main/java/com/module1/favorites/",
+        "2.9% W/src/main/java/com/module1/favorites/"
     )
 
     private val commandExecutor: CommandExecutor = mock {
@@ -35,15 +38,8 @@ class ChangedModulesKtTest {
 
     @Test
     fun `proves that changes get parsed correctly`() {
-        val expected = listOf<String>(
-            "module1",
-            "inbox",
-            "network",
-            "repositories",
-            "resources",
-            "favorites"
-        )
+        val expected = listOf("A", "B", "C", "D", "E", "F")
 
-        assertEquals(expected, changedModules(commandExecutor, "master"))
+        assertEquals(expected, changedModules(commandExecutor, "master", simpleGraph()))
     }
 }

--- a/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModulesTest.kt
+++ b/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ChangedModulesTest.kt
@@ -1,6 +1,7 @@
 package com.github.leandroborgesferreira.dagcommand.logic
 
 import com.github.leandroborgesferreira.dagcommand.utils.CommandExecutor
+import com.github.leandroborgesferreira.dagcommand.utils.simpleGraph
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -15,14 +16,15 @@ class ChangedModulesTest {
 
     @Test
     fun `should parse git modules correctly`() {
-        assertEquals(expectedModules(), changedModules(commandExecutor, "develop"))
+        assertEquals(expectedModules(), changedModules(commandExecutor, "develop", simpleGraph()))
     }
 }
 
 private fun commandExecList(): List<String> =
     listOf(
-        "25.0% core/src/main/java/com/something/android/core/extensions/",
-        "50.0% companyname/src/main/java/com/something/android/activities/fragments/blabla/"
+        "25.0% A/src/main/java/com/something/android/core/extensions/",
+        "50.0% B/src/main/java/com/something/android/activities/fragments/blabla/",
+        "25.0% Z/src/main/java/com/something/android/activities/fragments/blabla/"
     )
 
-private fun expectedModules(): List<String> = listOf("core", "companyname")
+private fun expectedModules(): List<String> = listOf("A", "B")

--- a/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
+++ b/src/test/kotlin/com/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
@@ -9,13 +9,6 @@ import kotlin.test.assertEquals
 class GraphKtTest {
 
     @Test
-    fun `proves that affected modules do not include folders that are not modules`() {
-        val resultSet = affectedModules(simpleGraph(), listOf("B", "C", "not", "in", "the", "graph"))
-
-        assertEquals(setOf("B", "C", "E", "F"), resultSet)
-    }
-
-    @Test
     fun `proves that affected graph works for middle position change`() {
         val resultSet = affectedModules(simpleGraph(), listOf("B", "C"))
 


### PR DESCRIPTION
Filtering changed modules. Changed folders must the inside the adjacency list.