### PR TITLE
Fix parsing dependencies for gradle wrapper 6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ out
 .DS_Store
 
 gradle.properties
+local.properties
 secret-ring.gpg

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 val artifactIdVal = "dag-command"
-val versionVal = "1.5.2"
+val versionVal = "1.5.3"
 val publicationName="dagCommand"
 
 group = "com.github.leandroborgesferreira"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Jun 01 16:36:08 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
+++ b/src/main/kotlin/com/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
@@ -33,4 +33,7 @@ private fun Project.parseDependencies(): List<Project> =
                 .map { projectDependency ->
                     projectDependency.dependencyProject
                 }
+                .filterNot { dependencyProject ->
+                  project.name == dependencyProject.name
+                }
         }


### PR DESCRIPTION
This PR removes self-dependencies, like `[module1] : [module2, module1]` from AdjacencyList