### PR TITLE
Cycle detection when parsing project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.konan.properties.Properties
 import java.io.FileInputStream
 
 val artifactIdVal = "dag-command"
-val versionVal = "1.10.0"
+val versionVal = "1.11.0"
 val publicationName = "dagCommand"
 
 group = "io.github.leandroborgesferreira"

--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/domain/exception/CycleDetectedException.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/domain/exception/CycleDetectedException.kt
@@ -1,0 +1,3 @@
+package io.github.leandroborgesferreira.dagcommand.domain.exception
+
+class CycleDetectedException(message: String) : IllegalStateException(message)

--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
@@ -5,16 +5,11 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 
 fun Project.toDagProjectList(filterModules: Set<String>): List<DagProject> =
-    project.subprojects.map { project ->
-        project.toDagProject(filterModules)
-    }
-
-private fun Project.toDagProject(filterModules: Set<String>): DagProject =
-    DagProject(
-        fullName = this.path,
-        dependencies = parseDependencies(filterModules).map { project ->
-            project.toDagProject(filterModules)
-        }.toSet()
+    project.subprojects.iterableToDagProjectT(
+        filterModules = filterModules,
+        visitedT = emptySet(),
+        getNext = { project -> project.parseDependencies(filterModules) },
+        getName = { project -> project.name },
     )
 
 private fun Project.parseDependencies(filterModules: Set<String>): List<Project> {

--- a/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
+++ b/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
@@ -1,8 +1,11 @@
 package io.github.leandroborgesferreira.dagcommand.logic
 
 import io.github.leandroborgesferreira.dagcommand.domain.Node
+import io.github.leandroborgesferreira.dagcommand.domain.exception.CycleDetectedException
+import io.github.leandroborgesferreira.dagcommand.utils.cyclicalObjectGraph
 import io.github.leandroborgesferreira.dagcommand.utils.disconnectedGraph
 import io.github.leandroborgesferreira.dagcommand.utils.graphWithCycle
+import io.github.leandroborgesferreira.dagcommand.utils.objectGraph
 import io.github.leandroborgesferreira.dagcommand.utils.simpleGraph
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -60,8 +63,31 @@ class GraphKtTest {
         assertEquals(expected, result)
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test(expected = CycleDetectedException::class)
     fun `proves that cycles are detected`() {
         affectedModules(graphWithCycle(), listOf(":A", ":B", ":C"))
     }
+
+    @Test(expected = CycleDetectedException::class)
+    fun `cycles are detected when building DagProject`() {
+        cyclicalObjectGraph()
+            .iterableToDagProjectT(
+                filterModules = emptySet(),
+                visitedT = emptySet(),
+                getNext = { project -> project.next },
+                getName = { project -> project.name },
+            )
+    }
+
+    @Test
+    fun `iterableToDagProjectT should work`() {
+        objectGraph()
+            .iterableToDagProjectT(
+                filterModules = emptySet(),
+                visitedT = emptySet(),
+                getNext = { project -> project.next },
+                getName = { project -> project.name },
+            )
+    }
 }
+

--- a/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
+++ b/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
@@ -86,3 +86,61 @@ fun disconnectedGraph(): Map<String, Set<String>> =
         ":E" to emptySet(),
         ":F" to emptySet()
     )
+
+fun cyclicalObjectGraph(): List<GraphNode> =
+    listOf(
+        GraphNode(
+            name = "A",
+            next = listOf(
+                GraphNode(
+                    name = "B",
+                    next = listOf(
+                        GraphNode(name = "A")
+                    )
+                )
+            )
+        )
+    )
+
+
+fun objectGraph(): List<GraphNode> =
+    listOf(
+        GraphNode(
+            name = "A",
+            next = listOf(
+                GraphNode(
+                    name = "B",
+                    next = listOf(
+                        GraphNode(name = "E")
+                    )
+                )
+            )
+        ),
+        GraphNode(
+            name = "C",
+            next = listOf(
+                GraphNode(
+                    name = "B",
+                    next = listOf(
+                        GraphNode(name = "E")
+                    )
+                )
+            )
+        ),
+        GraphNode(
+            name = "D",
+            next = listOf(
+                GraphNode(
+                    name = "B",
+                    next = listOf(
+                        GraphNode(name = "E")
+                    )
+                )
+            )
+        ),
+    )
+
+data class GraphNode(
+    val name: String,
+    val next: Iterable<GraphNode> = emptySet()
+)


### PR DESCRIPTION
Closes #34.

It adds cycle detection when parsing the project. Now the plugin presents a nice exception, instead of simply letting the project throw a StackOverflow error. 