### PR TITLE
Make command task public

### DIFF
--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/task/CommandTask.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/task/CommandTask.kt
@@ -14,7 +14,7 @@ abstract class CommandTask : DefaultTask() {
     lateinit var config: Config
 
     @TaskAction
-    private fun command() {
+    fun command() {
         printConfig(project, config)
 
         runDagCommand(


### PR DESCRIPTION
With Gradle 8.13 the behavior changed: https://docs.gradle.org/8.13/userguide/validation_problems.html#private_method_must_not_be_annotated