### PR TITLE
feat: support running with older JDKs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 val artifactIdVal = "dag-command"
 val versionVal = "1.13.0"
 val publicationName = "dagCommand"
@@ -39,6 +41,20 @@ tasks.withType<Copy>().all { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 java {
     withJavadocJar()
     withSourcesJar()
+}
+
+kotlin {
+    // Uses JDK 21 for compilation and tests
+    jvmToolchain(21)
+    compilerOptions {
+        // Output Kotlin bytecode compatible with JDK 11
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
+
+// Output Java bytecode compatible with JDK 11
+tasks.withType(JavaCompile::class.java).configureEach {
+    options.release = 11
 }
 
 gradlePlugin {


### PR DESCRIPTION
This PR makes it so Gradle will use JDK 21 for building and running tests / other Java-related tasks. But it will generate a bytecode that is compatible all the way down to JDK 11, like it was before.

Since [this commit](https://github.com/vitorhugods/dag-command/commit/54a2cc1a55a80a41efcf5689f76b4815fa3abf0f) it's not possible to use this plugin on machines using JDK 20 or older.

We have a project that does not support 21 yet. So we get:

```
Caused by: org.gradle.internal.resolve.ModuleVersionResolveException: Could not resolve io.github.leandroborgesferreira:dag-command:1.13.0.
Required by:
    root project : > io.github.leandroborgesferreira.dag-command:io.github.leandroborgesferreira.dag-command.gradle.plugin:1.13.0
Caused by: org.gradle.internal.component.resolution.failure.exception.VariantSelectionByAttributesException: Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.
```

I believe this requirement bump wasn't intended.