### PR TITLE
fix: use and output gradle project path instead of project name

### DIFF
--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/domain/Project.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/domain/Project.kt
@@ -1,8 +1,8 @@
 package io.github.leandroborgesferreira.dagcommand.domain
 
 data class DagProject(
-    val fullName: String,
+    val fullGradlePath: String,
     val dependencies: Set<DagProject>
 ) {
-    val lastName: String = fullName.split(":").last()
+    val lastName: String = fullGradlePath.split(":").last()
 }

--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/AdjacencyList.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/AdjacencyList.kt
@@ -7,13 +7,13 @@ fun parseAdjacencyList(projects: Iterable<DagProject>): Map<String, Set<String>>
     projects
         .let(::filterModules)
         .associate { subProject ->
-            val dependencies = subProject.dependencies.map { dep -> dep.fullName }.toSet()
-            subProject.fullName to dependencies
+            val dependencies = subProject.dependencies.map { dep -> dep.fullGradlePath }.toSet()
+            subProject.fullGradlePath to dependencies
         }.let(::revertAdjacencyList)
 
 private fun filterModules(projects: Iterable<DagProject>): Iterable<DagProject> {
     // All words present in the modules, divided by ':'
-    val allWords = projects.map { project -> project.fullName }
+    val allWords = projects.map { project -> project.fullGradlePath }
         .flatMap { name -> name.split(":") }
 
     /* When a word appears more than once, it means that it is actually a part of a path, not a

--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/Graph.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/Graph.kt
@@ -64,22 +64,22 @@ internal fun <T> Iterable<T>.iterableToDagProjectT(
     filterModules: Set<String>,
     visitedT: Set<String>,
     getNext: (T) -> Iterable<T>,
-    getName: (T) -> String
-) = map { project -> project.toDagProjectT(filterModules, visitedT, getNext, getName) }
+    getPath: (T) -> String
+) = map { project -> project.toDagProjectT(filterModules, visitedT, getNext, getPath) }
 
 internal fun <T> T.toDagProjectT(
     filterModules: Set<String>,
     visitedT: Set<String>,
     getNext: (T) -> Iterable<T>,
-    getName: (T) -> String,
+    getPath: (T) -> String,
 ): DagProject {
     val nextDependencies = getNext(this)
-    val nextNames = getNext(this).map(getName)
-    val name = getName(this)
+    val nextNames = getNext(this).map(getPath)
+    val path = getPath(this)
 
     println(
         """
-            Current module: $name
+            Current module: $path
             Next names: ${nextNames.joinToString()}
         """
     )
@@ -90,16 +90,16 @@ internal fun <T> T.toDagProjectT(
         throw CycleDetectedException(
             """
                 A cycle was detected in the graph of dependencies of your project.
-                These modules appeared more than once: $visitedAlready. Trying to visit from: $name.
+                These modules appeared more than once: $visitedAlready. Trying to visit from: $path.
                 All nodes visited already in this path: ${visitedT.joinToString()}
             """
         )
     }
 
     return DagProject(
-        fullName = name,
+        fullGradlePath = path,
         dependencies = nextDependencies.map { project ->
-            project.toDagProjectT(filterModules, visitedT + name, getNext, getName)
+            project.toDagProjectT(filterModules, visitedT + path, getNext, getPath)
         }.toSet()
     )
 }

--- a/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
+++ b/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/ProjectParse.kt
@@ -9,7 +9,7 @@ fun Project.toDagProjectList(filterModules: Set<String>): List<DagProject> =
         filterModules = filterModules,
         visitedT = emptySet(),
         getNext = { project -> project.parseDependencies(filterModules) },
-        getName = { project -> project.name },
+        getPath = { project -> project.path },
     )
 
 private fun Project.parseDependencies(filterModules: Set<String>): List<Project> {

--- a/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
+++ b/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/logic/GraphKtTest.kt
@@ -75,7 +75,7 @@ class GraphKtTest {
                 filterModules = emptySet(),
                 visitedT = emptySet(),
                 getNext = { project -> project.next },
-                getName = { project -> project.name },
+                getPath = { project -> project.path },
             )
     }
 
@@ -86,7 +86,7 @@ class GraphKtTest {
                 filterModules = emptySet(),
                 visitedT = emptySet(),
                 getNext = { project -> project.next },
-                getName = { project -> project.name },
+                getPath = { project -> project.path },
             )
     }
 }

--- a/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/task/CommandTaskTest.kt
+++ b/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/task/CommandTaskTest.kt
@@ -1,0 +1,64 @@
+package io.github.leandroborgesferreira.dagcommand.task
+
+import io.github.leandroborgesferreira.dagcommand.DagCommandPlugin
+import io.github.leandroborgesferreira.dagcommand.extension.CommandExtension
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class CommandTaskTest {
+
+    @Test
+    fun givenProjectStructure_whenTaskRuns_shouldUseGradleProjectPath() {
+        val root = rootProjectWithNesting()
+        DagCommandPlugin().apply(root)
+
+        root.extensions.configure(CommandExtension::class.java) {
+            it.outputType = "JSON"
+        }
+        val dagTask = root.tasks.withType(CommandTask::class.java).firstOrNull()
+        assertNotNull(dagTask)
+        dagTask.command()
+
+        val expectedAdjacenciesList = """{":plain":[],":parentOfOthers:nested-A":[],":parentOfOthers:nested-B":[]}"""
+        val adjacenciesListText = File(root.dagOutputDir(), "adjacencies-list.json").readText()
+
+        assertEquals(expectedAdjacenciesList, adjacenciesListText)
+    }
+
+    private fun Project.dagOutputDir() = File(layout.buildDirectory.asFile.get(), "dag-command")
+
+    private companion object {
+
+        fun rootProjectWithNesting(): Project {
+            val root = ProjectBuilder.builder()
+                .withName("root")
+                .build()
+
+            val parentSubproject = ProjectBuilder.builder()
+                .withName("parentOfOthers")
+                .withParent(root)
+                .build()
+
+            ProjectBuilder.builder()
+                .withName("nested-A")
+                .withParent(parentSubproject)
+                .build()
+
+            ProjectBuilder.builder()
+                .withName("nested-B")
+                .withParent(parentSubproject)
+                .build()
+
+            ProjectBuilder.builder()
+                .withName("plain")
+                .withParent(root)
+                .build()
+
+            return root
+        }
+    }
+}

--- a/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
+++ b/src/test/kotlin/io/github/leandroborgesferreira/dagcommand/utils/GraphGeneration.kt
@@ -4,46 +4,46 @@ import io.github.leandroborgesferreira.dagcommand.domain.DagProject
 import io.github.leandroborgesferreira.dagcommand.domain.Edge
 
 fun testProject() = listOf(
-    DagProject(fullName = ":application", dependencies = emptySet()),
-    DagProject(fullName = ":backend", dependencies = emptySet()),
-    DagProject(fullName = ":common", dependencies = emptySet()),
-    DagProject(fullName = ":libraries", dependencies = emptySet()),
-    DagProject(fullName = ":plugins", dependencies = emptySet()),
-    DagProject(fullName = ":writeopia", dependencies = emptySet()),
-    DagProject(fullName = ":writeopia_models", dependencies = emptySet()),
-    DagProject(fullName = ":writeopia_ui", dependencies = emptySet()),
-    DagProject(fullName = ":application:androidApp", dependencies = emptySet()),
-    DagProject(fullName = ":application:core", dependencies = emptySet()),
-    DagProject(fullName = ":application:desktopApp", dependencies = emptySet()),
-    DagProject(fullName = ":application:features", dependencies = emptySet()),
-    DagProject(fullName = ":application:web", dependencies = emptySet()),
-    DagProject(fullName = ":backend:documents", dependencies = emptySet()),
-    DagProject(fullName = ":backend:editor", dependencies = emptySet()),
-    DagProject(fullName = ":common:endpoints", dependencies = emptySet()),
-    DagProject(fullName = ":libraries:dbtest", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_export", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_import_document", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_network", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_persistence_core", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_persistence_room", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_persistence_sqldelight", dependencies = emptySet()),
-    DagProject(fullName = ":plugins:writeopia_serialization", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:auth_core", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:common_ui", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:common_ui_tests", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:persistence_bridge", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:persistence_room", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:persistence_sqldelight", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:resources", dependencies = emptySet()),
-    DagProject(fullName = ":application:core:utils", dependencies = emptySet()),
-    DagProject(fullName = ":application:features:account", dependencies = emptySet()),
-    DagProject(fullName = ":application:features:auth", dependencies = emptySet()),
-    DagProject(fullName = ":application:features:editor", dependencies = emptySet()),
-    DagProject(fullName = ":application:features:note_menu", dependencies = emptySet()),
-    DagProject(fullName = ":backend:documents:documents_spring", dependencies = emptySet()),
-    DagProject(fullName = ":backend:editor:api_editor", dependencies = emptySet()),
-    DagProject(fullName = ":backend:editor:api_editor_socket", dependencies = emptySet()),
-    DagProject(fullName = ":backend:editor:api_editor_spring", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":common", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":libraries", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":writeopia", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":writeopia_models", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":writeopia_ui", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:androidApp", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:desktopApp", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:features", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:web", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:documents", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:editor", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":common:endpoints", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":libraries:dbtest", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_export", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_import_document", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_network", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_persistence_core", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_persistence_room", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_persistence_sqldelight", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":plugins:writeopia_serialization", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:auth_core", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:common_ui", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:common_ui_tests", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:persistence_bridge", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:persistence_room", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:persistence_sqldelight", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:resources", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:core:utils", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:features:account", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:features:auth", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:features:editor", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":application:features:note_menu", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:documents:documents_spring", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:editor:api_editor", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:editor:api_editor_socket", dependencies = emptySet()),
+    DagProject(fullGradlePath = ":backend:editor:api_editor_spring", dependencies = emptySet()),
 )
 
 fun simpleGraph(): Map<String, Set<String>> =
@@ -90,12 +90,12 @@ fun disconnectedGraph(): Map<String, Set<String>> =
 fun cyclicalObjectGraph(): List<GraphNode> =
     listOf(
         GraphNode(
-            name = "A",
+            path = "A",
             next = listOf(
                 GraphNode(
-                    name = "B",
+                    path = "B",
                     next = listOf(
-                        GraphNode(name = "A")
+                        GraphNode(path = "A")
                     )
                 )
             )
@@ -106,34 +106,34 @@ fun cyclicalObjectGraph(): List<GraphNode> =
 fun objectGraph(): List<GraphNode> =
     listOf(
         GraphNode(
-            name = "A",
+            path = "A",
             next = listOf(
                 GraphNode(
-                    name = "B",
+                    path = "B",
                     next = listOf(
-                        GraphNode(name = "E")
+                        GraphNode(path = "E")
                     )
                 )
             )
         ),
         GraphNode(
-            name = "C",
+            path = "C",
             next = listOf(
                 GraphNode(
-                    name = "B",
+                    path = "B",
                     next = listOf(
-                        GraphNode(name = "E")
+                        GraphNode(path = "E")
                     )
                 )
             )
         ),
         GraphNode(
-            name = "D",
+            path = "D",
             next = listOf(
                 GraphNode(
-                    name = "B",
+                    path = "B",
                     next = listOf(
-                        GraphNode(name = "E")
+                        GraphNode(path = "E")
                     )
                 )
             )
@@ -141,6 +141,6 @@ fun objectGraph(): List<GraphNode> =
     )
 
 data class GraphNode(
-    val name: String,
+    val path: String,
     val next: Iterable<GraphNode> = emptySet()
 )


### PR DESCRIPTION
- Fixes #39 
- Fixes #40 

`Project.path` returns the full gradle path of a project, like: `:foo:bar`.
`Project.name` would return only the name of the project, like `bar`, without  the colon, or the parent project in the project tree.

It seems that this was broken in [this](https://github.com/leandroBorgesFerreira/dag-command/commit/da29d69212684bdcf98b3f3f9cc0dbe248cc9644) commit.

After diving deeper into the project, I guess this slipped through. I originally thought this behaviour (outputing `project.name` was intentional) and I was overcomplicating stuff in #41.

But it looks like multiple places in the project actually expect `Project.path` instead:
- The [`parseModuleName` function](https://github.com/LeandroBorgesFerreira/dag-command/blob/b6cf041da44a26df11a663bdd22ca220e559cf77/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/ChangedModules.kt#L36-L43) that relies on Project.path instead of Project.name
- The [`filterModules` function](https://github.com/leandroBorgesFerreira/dag-command/blob/5ca974075a455a4aece8e407f394b93e8304f291/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/logic/AdjacencyList.kt#L17), which also relies on Project.path instead of Project.name.
- The [`lastName` property](https://github.com/leandroBorgesFerreira/dag-command/blob/5ca974075a455a4aece8e407f394b93e8304f291/src/main/kotlin/io/github/leandroborgesferreira/dagcommand/domain/Project.kt#L7)

This PR also adds a more end-to-end test that applies the plugin to a test project structure, runs the task, and checks the output.